### PR TITLE
feat: activation 2FA sur compte existant et page /2fa/setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ Next.js (frontend) · Express.js (backend) · PostgreSQL + Drizzle (ORM) · Dock
 - [x] Mot de passe fort (12 caractères min., maj./min./chiffre/symbole) — `domain/auth/security-policy.ts` (`isStrongPassword`)
 - [x] Renouvellement obligatoire tous les 60 jours — `PASSWORD_MAX_AGE_DAYS = 60`, vérifié à chaque login (`needsPasswordReset`)
 - [x] Blocage après tentatives infructueuses — 5 tentatives (`MAX_FAILED_ATTEMPTS`) → verrouillage 15 min (`LOCK_DURATION_MS`), déverrouillage automatique après délai (pas d'action admin nécessaire)
-- [~] Authentification à deux facteurs (TOTP) — fonctionne à l'inscription (`enable2FA`) et au login (`totp-provider.adapter.ts`), **obligatoire pour `SUPER_ADMIN`**
-  - [ ] **Aucun endpoint pour activer la 2FA sur un compte déjà existant** → bloque définitivement tout `SUPER_ADMIN` créé sans 2FA (ne peut jamais se connecter). Endpoint `POST /auth/2fa/enable` + page `/2fa/setup` à créer en priorité
+- [x] Authentification à deux facteurs (TOTP) — fonctionne à l'inscription (`enable2FA`), au login (`totp-provider.adapter.ts`) et à l'activation sur compte existant (`POST /auth/2fa/enable`), **obligatoire pour `SUPER_ADMIN`**
+  - [x] Endpoint pour activer la 2FA sur un compte déjà existant — `POST /auth/2fa/enable` + page `/2fa/setup`
 - [ ] Confirmation par SMS (Twilio) en alternative au TOTP — non implémenté (non bloquant : un seul moyen de 2FA suffit)
 - [ ] OIDC/OAuth2 (Google, Facebook...) — non implémenté. `cahierDesCharges.md` §5.1 le marque explicitement **"(optionnel)"** → à confirmer à l'oral si un seul mode d'authentification (email/mdp) suffit pour la partie "Authentification Avancée" du sujet
 - [ ] Lien magique — non implémenté (idem, marqué optionnel dans le cahier des charges interne)
@@ -121,7 +121,7 @@ Next.js (frontend) · Express.js (backend) · PostgreSQL + Drizzle (ORM) · Dock
 Ces gaps backend conditionnent des pages listées en section 11 — à traiter en parallèle du travail front, pas après :
 
 - [ ] Endpoint mot de passe oublié par email (token à usage unique)
-- [ ] Endpoint d'activation de la 2FA sur un compte existant (`POST /auth/2fa/enable`)
+- [x] Endpoint d'activation de la 2FA sur un compte existant (`POST /auth/2fa/enable`)
 - [ ] Upload réel de fichiers (multipart + stockage disque/S3), au-delà de la simple création de métadonnées `POST /files`
 - [ ] Mécanisme de notifications temps réel (WebSocket) pour planning/notes/documents
 - [ ] Un moyen de lister les comptes en attente d'attribution de rôle (`pending_role_assignment`) — aujourd'hui `GET /admin/security/users` retourne tous les comptes mais ne distingue pas explicitement "sans rôle" des autres
@@ -178,8 +178,7 @@ Seulement 4 rôles (pas les 6-7 décrits dans `cahierDesCharges.md` §2, l'admin
   - Contenu actuel (à conserver) : champs email (pré-rempli si redirigé depuis `/login`), ancien mot de passe, nouveau mot de passe + confirmation, indicateur de force
   - À ajouter : si la page est ouverte avec un paramètre `?token=...` (lien reçu par email via `/forgot-password`), afficher un **second formulaire** sans champ "ancien mot de passe" (juste nouveau mot de passe + confirmation) — les deux usages ("renouvellement expiré" et "mot de passe oublié") ne doivent pas être confondus dans le même formulaire
 
-- [ ] **`/2fa/setup`** — 🆕, dépend d'un endpoint backend à créer (section 10)
-  - Contenu : QR code à scanner + secret affiché en texte (fallback si l'app ne peut pas scanner) · champ de saisie du code à 6 chiffres pour confirmer l'activation avant validation définitive · bouton "Valider et continuer"
+- [x] **`/2fa/setup`** — QR code + secret TOTP + confirmation par code à 6 chiffres
 
 ### 11.2 Commun à tous les rôles connectés
 

--- a/application/auth/auth.use-cases.ts
+++ b/application/auth/auth.use-cases.ts
@@ -59,7 +59,7 @@ export type LoginResult =
     | { kind: "pending_role_assignment" }
     | { kind: "account_locked"; lockedUntil: Date | null }
     | { kind: "password_expired"; passwordResetRequired: true }
-    | { kind: "super_admin_2fa_required"; setup2FARequired: true }
+    | { kind: "super_admin_2fa_required"; setup2FARequired: true; setupSessionToken: string }
     | { kind: "two_factor_required"; tempSessionToken: string }
     | AuthenticatedResult;
 
@@ -108,6 +108,15 @@ export type GdprExportResult =
       };
 
 export type DeleteAccountResult = { kind: "user_not_found" } | { kind: "account_deleted" };
+
+export type Enable2faResult =
+    | { kind: "unauthorized" }
+    | { kind: "invalid_session" }
+    | { kind: "already_enabled" }
+    | { kind: "missing_code" }
+    | { kind: "invalid_totp_code" }
+    | { kind: "setup_initiated"; totpSecret: string; totpProvisioningUri: string }
+    | { kind: "two_factor_enabled" };
 
 export class AuthUseCases {
     constructor(
@@ -204,8 +213,14 @@ export class AuthUseCases {
 
         if (needsPasswordReset(user.passwordUpdatedAt))
             return { kind: "password_expired", passwordResetRequired: true };
-        if (role === Role.SUPER_ADMIN && !user.twoFactorEnabled)
-            return { kind: "super_admin_2fa_required", setup2FARequired: true };
+        if (role === Role.SUPER_ADMIN && !user.twoFactorEnabled) {
+            const session = await this.twoFactorSessions.create(user.id);
+            return {
+                kind: "super_admin_2fa_required",
+                setup2FARequired: true,
+                setupSessionToken: session.token,
+            };
+        }
         if (user.twoFactorEnabled) {
             const session = await this.twoFactorSessions.create(user.id);
             return { kind: "two_factor_required", tempSessionToken: session.token };
@@ -333,6 +348,48 @@ export class AuthUseCases {
                 lastLoginAt: user.lastLoginAt,
             },
         };
+    }
+
+    async enable2fa(input: {
+        userId?: string;
+        setupSessionToken?: string;
+        code?: string;
+    }): Promise<Enable2faResult> {
+        const userId = await this.resolveEnable2faUserId(input.userId, input.setupSessionToken);
+        if (!userId) return { kind: "unauthorized" };
+
+        const user = await this.users.findById(userId);
+        if (!user) return { kind: "unauthorized" };
+        if (user.twoFactorEnabled) return { kind: "already_enabled" };
+
+        if (!input.code) {
+            user.twoFactorSecret = this.totp.generateSecret(user.email);
+            await this.users.save(user);
+            return {
+                kind: "setup_initiated",
+                totpSecret: user.twoFactorSecret,
+                totpProvisioningUri: this.totp.buildProvisioningUri(user.email, user.twoFactorSecret),
+            };
+        }
+
+        if (!user.twoFactorSecret) return { kind: "invalid_session" };
+        if (!this.totp.verify(user.twoFactorSecret, input.code)) return { kind: "invalid_totp_code" };
+
+        user.twoFactorEnabled = true;
+        await this.users.save(user);
+        if (input.setupSessionToken) await this.twoFactorSessions.delete(input.setupSessionToken);
+        return { kind: "two_factor_enabled" };
+    }
+
+    private async resolveEnable2faUserId(
+        userId?: string,
+        setupSessionToken?: string,
+    ): Promise<string | undefined> {
+        if (userId) return userId;
+        if (!setupSessionToken) return undefined;
+        const notBefore = new Date(Date.now() - TWO_FACTOR_SESSION_EXPIRY_MS);
+        const session = await this.twoFactorSessions.find(setupSessionToken, notBefore);
+        return session?.userId;
     }
 
     async cleanupExpiredSessions(): Promise<void> {

--- a/infrastructure/backend/express/src/auth/routes.ts
+++ b/infrastructure/backend/express/src/auth/routes.ts
@@ -1,4 +1,5 @@
 import {
+    type Enable2faResult,
     type GetMeResult,
     type LoginResult,
     type ResetPasswordResult,
@@ -7,6 +8,7 @@ import {
 } from "@application/auth/auth.use-cases";
 import { Router } from "express";
 import { requireAuth, requireCronSecret, requireRole, type AuthRequest } from "@express/src/auth/middleware";
+import { tokenProvider } from "@express/src/auth/token-provider.adapter";
 import { AdminRole } from "@domain/admin/admin.enums";
 import { authUseCases } from "@express/src/container";
 
@@ -22,13 +24,18 @@ type LoginResponseBody =
     | { error: string }
     | { error: string; lockedUntil?: string }
     | { error: string; passwordResetRequired: true }
-    | { error: string; setup2FARequired: true }
+    | { error: string; setup2FARequired: true; setupSessionToken?: string }
     | { twoFactorRequired: true; tempSessionToken: string }
     | { token: string; user: AuthUserView };
 
 type Verify2faResponseBody = { error: string } | { token: string; user: AuthUserView };
 
 type ResetPasswordResponseBody = { error: string } | { message: string };
+
+type Enable2faResponseBody =
+    | { error: string }
+    | { totpSecret: string; totpProvisioningUri: string }
+    | { message: string };
 
 type GetMeResponseBody =
     | { error: string }
@@ -93,7 +100,11 @@ const loginResponse = (result: LoginResult): { status: number; body: LoginRespon
         case "super_admin_2fa_required":
             return {
                 status: 403,
-                body: { error: "Super admin must enable TOTP 2FA.", setup2FARequired: result.setup2FARequired },
+                body: {
+                    error: "Super admin must enable TOTP 2FA.",
+                    setup2FARequired: result.setup2FARequired,
+                    setupSessionToken: result.setupSessionToken,
+                },
             };
         case "two_factor_required":
             return { status: 200, body: { twoFactorRequired: true, tempSessionToken: result.tempSessionToken } };
@@ -145,6 +156,28 @@ const getMeResponse = (result: GetMeResult): { status: number; body: GetMeRespon
     }
 };
 
+const enable2faResponse = (result: Enable2faResult): { status: number; body: Enable2faResponseBody } => {
+    switch (result.kind) {
+        case "unauthorized":
+            return { status: 401, body: { error: "Unauthorized" } };
+        case "invalid_session":
+            return { status: 401, body: { error: "Invalid or expired setup session" } };
+        case "already_enabled":
+            return { status: 409, body: { error: "Two-factor authentication is already enabled" } };
+        case "missing_code":
+            return { status: 400, body: { error: "TOTP code is required to confirm activation" } };
+        case "invalid_totp_code":
+            return { status: 401, body: { error: "Invalid TOTP code" } };
+        case "setup_initiated":
+            return {
+                status: 200,
+                body: { totpSecret: result.totpSecret, totpProvisioningUri: result.totpProvisioningUri },
+            };
+        case "two_factor_enabled":
+            return { status: 200, body: { message: "Two-factor authentication enabled" } };
+    }
+};
+
 authRouter.post("/auth/signup", async (request, response) => {
     const httpResponse = signupResponse(await authUseCases.signup(request.body));
     response.status(httpResponse.status).json(httpResponse.body);
@@ -157,6 +190,23 @@ authRouter.post("/auth/login", async (request, response) => {
 
 authRouter.post("/auth/login/2fa", async (request, response) => {
     const httpResponse = verify2faResponse(await authUseCases.verify2fa(request.body));
+    response.status(httpResponse.status).json(httpResponse.body);
+});
+
+authRouter.post("/auth/2fa/enable", async (request: AuthRequest, response) => {
+    const { code, setupSessionToken } = request.body as { code?: string; setupSessionToken?: string };
+    const authorization = request.headers.authorization;
+    let userId: string | undefined;
+    if (authorization?.startsWith("Bearer ")) {
+        try {
+            userId = tokenProvider.verify(authorization.slice("Bearer ".length)).sub;
+        } catch {
+            userId = undefined;
+        }
+    }
+
+    const result = await authUseCases.enable2fa({ userId, setupSessionToken, code });
+    const httpResponse = enable2faResponse(result);
     response.status(httpResponse.status).json(httpResponse.body);
 });
 

--- a/infrastructure/frontend/next/app/(app)/parametres/page.tsx
+++ b/infrastructure/frontend/next/app/(app)/parametres/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { User, Lock, Bell, Shield, Trash2, Eye, EyeOff, CheckCircle, Smartphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -224,10 +225,18 @@ export default function Parametres() {
                                 {!twoFA && (
                                     <div className="flex items-center gap-3 p-4 bg-orange-50 border border-orange-200 rounded-xl">
                                         <Smartphone size={18} className="text-orange-500 flex-shrink-0" />
-                                        <p className="text-sm text-orange-700">
-                                            Activez la 2FA pour renforcer la sécurité de votre compte. Scannez le QR
-                                            code avec votre application TOTP.
-                                        </p>
+                                        <div className="flex-1">
+                                            <p className="text-sm text-orange-700">
+                                                Activez la 2FA pour renforcer la sécurité de votre compte. Scannez le QR
+                                                code avec votre application TOTP.
+                                            </p>
+                                            <Link
+                                                href="/2fa/setup"
+                                                className="inline-block mt-3 px-4 py-2 bg-[#001944] text-white text-xs font-semibold rounded-lg hover:bg-[#002C6E] transition-colors"
+                                            >
+                                                Configurer la 2FA
+                                            </Link>
+                                        </div>
                                     </div>
                                 )}
                             </div>

--- a/infrastructure/frontend/next/app/2fa/setup/TwoFactorSetupContent.tsx
+++ b/infrastructure/frontend/next/app/2fa/setup/TwoFactorSetupContent.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ChangeEvent, type FormEvent } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { CheckCircle, Smartphone } from "lucide-react";
+
+type SetupState = "loading" | "ready" | "success" | "error";
+
+export default function TwoFactorSetupPage() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const setupSessionToken = searchParams.get("token") ?? "";
+
+    const [state, setState] = useState<SetupState>("loading");
+    const [totpSecret, setTotpSecret] = useState("");
+    const [totpProvisioningUri, setTotpProvisioningUri] = useState("");
+    const [code, setCode] = useState("");
+    const [error, setError] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    const authHeaders = useCallback((): HeadersInit => {
+        const headers: HeadersInit = { "Content-Type": "application/json" };
+        const token = typeof window !== "undefined" ? localStorage.getItem("myges_token") : null;
+        if (token) headers.Authorization = `Bearer ${token}`;
+        return headers;
+    }, []);
+
+    const initSetup = useCallback(async () => {
+        const token = typeof window !== "undefined" ? localStorage.getItem("myges_token") : null;
+        if (!setupSessionToken && !token) {
+            setState("error");
+            setError("Session invalide. Reconnectez-vous pour configurer la 2FA.");
+            return;
+        }
+
+        setState("loading");
+        setError("");
+        try {
+            const response = await fetch("/api/auth/2fa/enable", {
+                method: "POST",
+                headers: authHeaders(),
+                body: JSON.stringify(setupSessionToken ? { setupSessionToken } : {}),
+            });
+            const payload = (await response.json()) as {
+                error?: string;
+                totpSecret?: string;
+                totpProvisioningUri?: string;
+            };
+
+            if (!response.ok) {
+                setState("error");
+                setError(payload.error ?? "Impossible d'initialiser la configuration 2FA.");
+                return;
+            }
+
+            if (payload.totpSecret && payload.totpProvisioningUri) {
+                setTotpSecret(payload.totpSecret);
+                setTotpProvisioningUri(payload.totpProvisioningUri);
+                setState("ready");
+                return;
+            }
+
+            setState("error");
+            setError("Réponse serveur invalide.");
+        } catch {
+            setState("error");
+            setError("Serveur indisponible.");
+        }
+    }, [authHeaders, setupSessionToken]);
+
+    useEffect(() => {
+        void initSetup();
+    }, [initSetup]);
+
+    const handleConfirm = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setSubmitting(true);
+        setError("");
+        try {
+            const response = await fetch("/api/auth/2fa/enable", {
+                method: "POST",
+                headers: authHeaders(),
+                body: JSON.stringify({
+                    ...(setupSessionToken ? { setupSessionToken } : {}),
+                    code,
+                }),
+            });
+            const payload = (await response.json()) as { error?: string; message?: string };
+
+            if (!response.ok) {
+                setError(payload.error ?? "Code TOTP invalide.");
+                return;
+            }
+
+            setState("success");
+            const hasAuthToken = typeof window !== "undefined" && localStorage.getItem("myges_token");
+            setTimeout(() => {
+                router.push(hasAuthToken ? "/parametres" : "/login");
+            }, 2000);
+        } catch {
+            setError("Erreur lors de la validation du code.");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const qrImageUrl = totpProvisioningUri
+        ? `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(totpProvisioningUri)}`
+        : "";
+
+    return (
+        <div
+            className="min-h-screen flex items-center justify-center px-4"
+            style={{ background: "linear-gradient(135deg, #001944 0%, #002C6E 55%, #1d4ed8 100%)" }}
+        >
+            <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8">
+                <div className="flex items-center gap-3 mb-2">
+                    <div className="w-10 h-10 rounded-xl bg-[#001944]/10 flex items-center justify-center">
+                        <Smartphone size={20} className="text-[#001944]" />
+                    </div>
+                    <h1 className="text-2xl font-bold text-gray-900">Configurer la 2FA</h1>
+                </div>
+                <p className="text-sm text-gray-500 mb-6">
+                    Scannez le QR code avec Google Authenticator, Authy ou une application TOTP compatible.
+                </p>
+
+                {state === "loading" && (
+                    <p className="text-sm text-gray-500 text-center py-8">Génération du QR code…</p>
+                )}
+
+                {state === "error" && (
+                    <div className="space-y-4">
+                        <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg p-3">{error}</p>
+                        <Link
+                            href="/login"
+                            className="block text-center text-sm text-blue-700 hover:text-blue-900 font-medium"
+                        >
+                            Retour à la connexion
+                        </Link>
+                    </div>
+                )}
+
+                {state === "success" && (
+                    <div className="flex flex-col items-center gap-3 py-6 text-green-700">
+                        <CheckCircle size={40} />
+                        <p className="font-semibold">2FA activée avec succès !</p>
+                        <p className="text-sm text-gray-500">Redirection en cours…</p>
+                    </div>
+                )}
+
+                {state === "ready" && (
+                    <div className="space-y-5">
+                        <div className="flex flex-col items-center gap-3 p-4 bg-gray-50 border border-gray-200 rounded-xl">
+                            {qrImageUrl && (
+                                <img
+                                    src={qrImageUrl}
+                                    alt="QR code pour la 2FA"
+                                    width={200}
+                                    height={200}
+                                    className="rounded-lg"
+                                />
+                            )}
+                            <div className="w-full">
+                                <p className="text-xs text-gray-500 mb-1 text-center">
+                                    Impossible de scanner ? Saisissez ce secret manuellement :
+                                </p>
+                                <code className="block text-xs text-center font-mono bg-white border border-gray-200 rounded-lg px-3 py-2 break-all select-all">
+                                    {totpSecret}
+                                </code>
+                            </div>
+                        </div>
+
+                        <form onSubmit={handleConfirm} className="space-y-3">
+                            <div>
+                                <label className="text-xs font-medium text-gray-700 block mb-1">
+                                    Code de vérification à 6 chiffres
+                                </label>
+                                <input
+                                    type="text"
+                                    inputMode="numeric"
+                                    placeholder="123456"
+                                    value={code}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                                        setCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                                    }
+                                    className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400"
+                                    required
+                                />
+                            </div>
+
+                            {error && (
+                                <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2">
+                                    {error}
+                                </p>
+                            )}
+
+                            <button
+                                type="submit"
+                                disabled={submitting || code.length !== 6}
+                                className={cn(
+                                    "w-full py-2.5 rounded-xl font-semibold text-sm text-white transition-all",
+                                    !submitting && code.length === 6
+                                        ? "bg-[#001944] hover:bg-[#002C6E] cursor-pointer"
+                                        : "bg-gray-300 cursor-not-allowed",
+                                )}
+                            >
+                                {submitting ? "Validation…" : "Valider et continuer"}
+                            </button>
+                        </form>
+                    </div>
+                )}
+
+                {state === "ready" && (
+                    <p className="mt-4 text-xs text-center">
+                        <Link href="/login" className="text-blue-700 hover:text-blue-900 font-medium">
+                            Retour à la connexion
+                        </Link>
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/infrastructure/frontend/next/app/2fa/setup/page.tsx
+++ b/infrastructure/frontend/next/app/2fa/setup/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+import TwoFactorSetupPage from "./TwoFactorSetupContent";
+
+export default function TwoFactorSetupPageWrapper() {
+    return (
+        <Suspense
+            fallback={
+                <div
+                    className="min-h-screen flex items-center justify-center px-4"
+                    style={{ background: "linear-gradient(135deg, #001944 0%, #002C6E 55%, #1d4ed8 100%)" }}
+                >
+                    <p className="text-white text-sm">Chargement…</p>
+                </div>
+            }
+        >
+            <TwoFactorSetupPage />
+        </Suspense>
+    );
+}

--- a/infrastructure/frontend/next/app/login/page.tsx
+++ b/infrastructure/frontend/next/app/login/page.tsx
@@ -56,11 +56,17 @@ export default function LoginPage() {
                 token?: string;
                 user?: { role?: string };
                 passwordResetRequired?: boolean;
+                setup2FARequired?: boolean;
+                setupSessionToken?: string;
             };
 
             if (!response.ok) {
                 if (payload.passwordResetRequired) {
                     router.push(`/reset-password?email=${encodeURIComponent(email)}`);
+                    return;
+                }
+                if (payload.setup2FARequired && payload.setupSessionToken) {
+                    router.push(`/2fa/setup?token=${encodeURIComponent(payload.setupSessionToken)}`);
                     return;
                 }
                 setError(payload.error ?? "Connexion impossible.");


### PR DESCRIPTION
Permet aux utilisateurs connectes ou aux super admins en attente de configurer le TOTP via POST /auth/2fa/enable, avec redirection depuis le login et les parametres.