### PR TITLE
feat: mot de passe oublie par email avec token a usage unique

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,5 @@ JWT_SECRET=change-this-to-a-long-random-string-in-real-use
 FRONTEND_PORT=3000
 # Nom du service docker-compose, pas "localhost"
 API_URL=http://backend:3001
+# URL publique du frontend (liens dans les e-mails de réinitialisation de mot de passe)
+FRONTEND_PUBLIC_URL=http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,10 @@ Next.js (frontend) · Express.js (backend) · PostgreSQL + Drizzle (ORM) · Dock
 
 - [x] Inscription — `POST /auth/signup`, front `/signup` branché
 - [x] Connexion — `POST /auth/login` (+ étape 2FA `POST /auth/login/2fa`), front `/login` branché
-- [ ] **Mot de passe oublié** (vrai flux par email, sans connaître l'ancien mot de passe) — **aucun endpoint backend, aucune page front**
-  - [ ] Backend : générer un token à usage unique + expiration, endpoint d'envoi d'email, endpoint de confirmation
-  - [ ] Front : page `/forgot-password` (saisie email) + page de confirmation (`/reset-password?token=...`)
-- [~] Réinitialisation de mot de passe — existe uniquement en mode "renouvellement forcé tous les 60 jours" (`POST /auth/password/reset-with-credentials`, nécessite email + ancien mdp + nouveau mdp)
-  - [ ] Ce n'est pas un "mot de passe oublié" : il faut déjà connaître l'ancien mot de passe. À bien distinguer les deux usages sur `/reset-password`
+- [x] **Mot de passe oublié** (vrai flux par email, sans connaître l'ancien mot de passe)
+  - [x] Backend : token à usage unique + expiration (`POST /auth/password/forgot`, `POST /auth/password/reset-with-token`), envoi d'email (log console en dev via `email-sender.adapter.ts`)
+  - [x] Front : page `/forgot-password` + confirmation via `/reset-password?token=...`
+- [x] Réinitialisation de mot de passe — deux usages distincts sur `/reset-password` : renouvellement forcé (email + ancien mdp) via `POST /auth/password/reset-with-credentials` · mot de passe oublié (token email, sans ancien mdp) via `POST /auth/password/reset-with-token`
 - [x] Mot de passe fort (12 caractères min., maj./min./chiffre/symbole) — `domain/auth/security-policy.ts` (`isStrongPassword`)
 - [x] Renouvellement obligatoire tous les 60 jours — `PASSWORD_MAX_AGE_DAYS = 60`, vérifié à chaque login (`needsPasswordReset`)
 - [x] Blocage après tentatives infructueuses — 5 tentatives (`MAX_FAILED_ATTEMPTS`) → verrouillage 15 min (`LOCK_DURATION_MS`), déverrouillage automatique après délai (pas d'action admin nécessaire)
@@ -120,7 +119,7 @@ Next.js (frontend) · Express.js (backend) · PostgreSQL + Drizzle (ORM) · Dock
 
 Ces gaps backend conditionnent des pages listées en section 11 — à traiter en parallèle du travail front, pas après :
 
-- [ ] Endpoint mot de passe oublié par email (token à usage unique)
+- [x] Endpoint mot de passe oublié par email (token à usage unique)
 - [x] Endpoint d'activation de la 2FA sur un compte existant (`POST /auth/2fa/enable`)
 - [ ] Upload réel de fichiers (multipart + stockage disque/S3), au-delà de la simple création de métadonnées `POST /files`
 - [ ] Mécanisme de notifications temps réel (WebSocket) pour planning/notes/documents
@@ -172,12 +171,8 @@ Seulement 4 rôles (pas les 6-7 décrits dans `cahierDesCharges.md` §2, l'admin
   - À retirer : le sélecteur de rôle actuel (le champ envoyé n'est lu par aucun endpoit backend)
   - Endpoint : `POST /auth/signup`
 
-- [ ] **`/forgot-password`** — 🆕, dépend d'un endpoint backend à créer (section 10)
-  - Contenu : un seul champ email + bouton "Envoyer le lien de réinitialisation" · message de confirmation neutre après envoi (ne jamais indiquer si l'email existe en base, c'est une fuite d'information)
-
-- [~] **`/reset-password`** — branché sur `POST /auth/password/reset-with-credentials`
-  - Contenu actuel (à conserver) : champs email (pré-rempli si redirigé depuis `/login`), ancien mot de passe, nouveau mot de passe + confirmation, indicateur de force
-  - À ajouter : si la page est ouverte avec un paramètre `?token=...` (lien reçu par email via `/forgot-password`), afficher un **second formulaire** sans champ "ancien mot de passe" (juste nouveau mot de passe + confirmation) — les deux usages ("renouvellement expiré" et "mot de passe oublié") ne doivent pas être confondus dans le même formulaire
+- [x] **`/forgot-password`** — saisie email + message de confirmation neutre après envoi
+- [x] **`/reset-password`** — deux formulaires selon le contexte : renouvellement expiré (email + ancien + nouveau mdp) · lien email `?token=...` (nouveau mdp + confirmation, sans ancien mdp)
 
 - [x] **`/2fa/setup`** — QR code + secret TOTP + confirmation par code à 6 chiffres
 
@@ -347,5 +342,5 @@ Fusionne les responsabilités "Scolarité / Pédagogique / Relations Entreprises
 4. ~~Zone Administration (`/scolarite/*`)~~ ✅ fait — les 13 pages (année académique, campus, formations, classes, intervenants, cours, planning, étudiants, absences, documents, entreprises, externes, examens) sont construites. `Sidebar.tsx` mis à jour avec les 13 entrées de menu correspondantes
 5. ~~`/etudiant/cours` + `/etudiant/evaluations` + `/intervenant/evaluations` (boucle supports/rendus complète)~~ ✅ fait — `Sidebar.tsx`/`TopBar.tsx` mis à jour avec les 3 entrées de menu/titres correspondants
 6. ~~`/superadmin/securite` (audit-log détaillé, filtres)~~ ✅ fait
-7. `/forgot-password` + `/2fa/setup` une fois les endpoints back correspondants ajoutés (section 10) — `/2fa/setup` fait entretemps, `/forgot-password` reste à faire
+7. ~~`/forgot-password` + `/2fa/setup`~~ ✅ fait
 8. ~~Composants à mutualiser (modal de confirmation, toast, badge de statut)~~ ✅ fait — `StatusBadge`/`ConfirmDialog`/`useToast`, déployés sur les suppressions d'entité et les badges de statut dupliqués (détail section 11.7). Table générique et dropzone d'upload restent à faire

--- a/application/auth/auth.use-cases.ts
+++ b/application/auth/auth.use-cases.ts
@@ -22,11 +22,14 @@ import { type TokenProvider } from "@application/auth/token-provider.port";
 import { type TotpProvider } from "@application/auth/totp-provider.port";
 import { type UserRepository } from "@application/auth/user.repository";
 import { type TwoFactorSessionRepository } from "@application/auth/two-factor-session.repository";
+import { type PasswordResetTokenRepository } from "@application/auth/password-reset-token.repository";
+import { type EmailSender } from "@application/auth/email-sender.port";
 import { type AuthContext } from "@application/types/auth-context";
 import { Forbidden } from "@application/types/results";
 
 const MAX_2FA_ATTEMPTS = 5;
 const TWO_FACTOR_SESSION_EXPIRY_MS = 5 * 60 * 1000;
+const PASSWORD_RESET_TOKEN_EXPIRY_MS = 60 * 60 * 1000;
 
 type RoleKey = keyof typeof Role;
 
@@ -80,7 +83,13 @@ export type ResetPasswordResult =
     | { kind: "weak_password" }
     | { kind: "user_not_found" }
     | { kind: "invalid_old_password" }
+    | { kind: "invalid_or_expired_token" }
     | { kind: "password_updated" };
+
+export type RequestPasswordResetResult =
+    | { kind: "missing_email" }
+    | { kind: "invalid_email" }
+    | { kind: "reset_email_sent" };
 
 export type GetMeResult =
     | { kind: "user_not_found" }
@@ -148,6 +157,9 @@ export class AuthUseCases {
         private readonly tokens: TokenProvider,
         private readonly totp: TotpProvider,
         private readonly twoFactorSessions: TwoFactorSessionRepository,
+        private readonly passwordResetTokens: PasswordResetTokenRepository,
+        private readonly emailSender: EmailSender,
+        private readonly frontendPublicUrl: string,
     ) {}
 
     private async resolveRole(userId: string): Promise<Role | undefined> {
@@ -286,6 +298,43 @@ export class AuthUseCases {
         const user = await this.users.findByEmail(email.toLowerCase());
         if (!user) return { kind: "user_not_found" };
         if (!(await this.hasher.verify(user.passwordHash, oldPassword))) return { kind: "invalid_old_password" };
+        return this.applyPasswordUpdate(user, newPassword);
+    }
+
+    async requestPasswordReset(input: { email?: string }): Promise<RequestPasswordResetResult> {
+        const email = input.email?.trim();
+        if (!email) return { kind: "missing_email" };
+        if (!emailIsValid(email)) return { kind: "invalid_email" };
+
+        const user = await this.users.findByEmail(email.toLowerCase());
+        if (user) {
+            await this.passwordResetTokens.deleteByUserId(user.id);
+            const resetToken = await this.passwordResetTokens.create(user.id);
+            const resetUrl = `${this.frontendPublicUrl}/reset-password?token=${encodeURIComponent(resetToken.token)}`;
+            await this.emailSender.sendPasswordResetEmail({ to: user.email, resetUrl });
+        }
+
+        return { kind: "reset_email_sent" };
+    }
+
+    async resetWithToken(input: { token?: string; newPassword?: string }): Promise<ResetPasswordResult> {
+        const { token, newPassword } = input;
+        if (!token || !newPassword) return { kind: "missing_reset_payload" };
+        if (!isStrongPassword(newPassword)) return { kind: "weak_password" };
+
+        const notBefore = new Date(Date.now() - PASSWORD_RESET_TOKEN_EXPIRY_MS);
+        const resetToken = await this.passwordResetTokens.find(token, notBefore);
+        if (!resetToken) return { kind: "invalid_or_expired_token" };
+
+        const user = await this.users.findById(resetToken.userId);
+        if (!user) return { kind: "invalid_or_expired_token" };
+
+        await this.applyPasswordUpdate(user, newPassword);
+        await this.passwordResetTokens.delete(resetToken.token);
+        return { kind: "password_updated" };
+    }
+
+    private async applyPasswordUpdate(user: User, newPassword: string): Promise<ResetPasswordResult> {
         user.passwordHash = await this.hasher.hash(newPassword);
         user.passwordUpdatedAt = new Date();
         user.failedAttempts = 0;
@@ -328,12 +377,7 @@ export class AuthUseCases {
         const user = await this.users.findById(userId);
         if (!user) return { kind: "user_not_found" };
         if (!(await this.hasher.verify(user.passwordHash, oldPassword))) return { kind: "invalid_old_password" };
-        user.passwordHash = await this.hasher.hash(newPassword);
-        user.passwordUpdatedAt = new Date();
-        user.failedAttempts = 0;
-        user.lockedUntil = null;
-        await this.users.save(user);
-        return { kind: "password_updated" };
+        return this.applyPasswordUpdate(user, newPassword);
     }
 
     async listUsersForAdmin(auth: AuthContext): Promise<ListUsersResult> {
@@ -414,8 +458,10 @@ export class AuthUseCases {
     }
 
     async cleanupExpiredSessions(): Promise<void> {
-        const cutoff = new Date(Date.now() - TWO_FACTOR_SESSION_EXPIRY_MS);
-        await this.twoFactorSessions.deleteOlderThan(cutoff);
+        const twoFactorCutoff = new Date(Date.now() - TWO_FACTOR_SESSION_EXPIRY_MS);
+        await this.twoFactorSessions.deleteOlderThan(twoFactorCutoff);
+        const passwordResetCutoff = new Date(Date.now() - PASSWORD_RESET_TOKEN_EXPIRY_MS);
+        await this.passwordResetTokens.deleteOlderThan(passwordResetCutoff);
     }
 
     async deleteAccount(userId: string, auth: AuthContext): Promise<DeleteAccountResult> {

--- a/application/auth/email-sender.port.ts
+++ b/application/auth/email-sender.port.ts
@@ -1,0 +1,3 @@
+export interface EmailSender {
+    sendPasswordResetEmail(input: { to: string; resetUrl: string }): Promise<void>;
+}

--- a/application/auth/password-reset-token.repository.ts
+++ b/application/auth/password-reset-token.repository.ts
@@ -1,0 +1,9 @@
+import { type PasswordResetToken } from "@domain/auth/password-reset-token.entity";
+
+export interface PasswordResetTokenRepository {
+    create(userId: string): Promise<PasswordResetToken>;
+    find(token: string, notBefore: Date): Promise<PasswordResetToken | undefined>;
+    delete(token: string): Promise<void>;
+    deleteByUserId(userId: string): Promise<void>;
+    deleteOlderThan(cutoff: Date): Promise<void>;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:?}
       POSTGRES_USER: ${POSTGRES_USER:?}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
+      FRONTEND_PUBLIC_URL: ${FRONTEND_PUBLIC_URL:-http://localhost:3000}
     depends_on:
       postgres:
         condition: service_healthy

--- a/domain/auth/password-reset-token.entity.ts
+++ b/domain/auth/password-reset-token.entity.ts
@@ -1,0 +1,5 @@
+export type PasswordResetToken = {
+    token: string;
+    userId: string;
+    createdAt: Date;
+};

--- a/infrastructure/backend/express/drizzle/0006_password_reset_tokens.sql
+++ b/infrastructure/backend/express/drizzle/0006_password_reset_tokens.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "password_reset_tokens" (
+	"token" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/infrastructure/backend/express/drizzle/meta/_journal.json
+++ b/infrastructure/backend/express/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783562090034,
       "tag": "0005_sad_the_leader",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783600000000,
+      "tag": "0006_password_reset_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/infrastructure/backend/express/src/auth/email-sender.adapter.ts
+++ b/infrastructure/backend/express/src/auth/email-sender.adapter.ts
@@ -1,0 +1,7 @@
+import { type EmailSender } from "@application/auth/email-sender.port";
+
+export const emailSender: EmailSender = {
+    async sendPasswordResetEmail({ to, resetUrl }) {
+        console.log(`[email] Password reset link for ${to}: ${resetUrl}`);
+    },
+};

--- a/infrastructure/backend/express/src/auth/routes.ts
+++ b/infrastructure/backend/express/src/auth/routes.ts
@@ -2,6 +2,7 @@ import {
     type Enable2faResult,
     type GetMeResult,
     type LoginResult,
+    type RequestPasswordResetResult,
     type ResetPasswordResult,
     type Verify2faResult,
 } from "@application/auth/auth.use-cases";
@@ -105,8 +106,29 @@ const resetPasswordResponse = (result: ResetPasswordResult): { status: HttpStatu
             return { status: 404, body: { error: "User not found" } };
         case "invalid_old_password":
             return { status: 401, body: { error: "Invalid old password" } };
+        case "invalid_or_expired_token":
+            return { status: 401, body: { error: "Invalid or expired reset token" } };
         case "password_updated":
             return { status: 200, body: { message: "Password updated" } };
+    }
+};
+
+const requestPasswordResetResponse = (
+    result: RequestPasswordResetResult,
+): { status: HttpStatus; body: ResetPasswordResponseBody } => {
+    switch (result.kind) {
+        case "missing_email":
+            return { status: 400, body: { error: "Email is required" } };
+        case "invalid_email":
+            return { status: 400, body: { error: "Invalid email format" } };
+        case "reset_email_sent":
+            return {
+                status: 200,
+                body: {
+                    message:
+                        "If an account exists for this email, a password reset link has been sent.",
+                },
+            };
     }
 };
 
@@ -205,6 +227,20 @@ authRouter.post("/auth/password/reset", ...authed(async (request, response) => {
 
 authRouter.post("/auth/password/reset-with-credentials", async (request, response) => {
     const httpResponse = resetPasswordResponse(await authUseCases.resetWithCredentials(request.body));
+    send(response, { status: httpResponse.status, body: httpResponse.body });
+});
+
+authRouter.post("/auth/password/forgot", async (request, response) => {
+    const httpResponse = requestPasswordResetResponse(
+        await authUseCases.requestPasswordReset(request.body as { email?: string }),
+    );
+    send(response, { status: httpResponse.status, body: httpResponse.body });
+});
+
+authRouter.post("/auth/password/reset-with-token", async (request, response) => {
+    const httpResponse = resetPasswordResponse(
+        await authUseCases.resetWithToken(request.body as { token?: string; newPassword?: string }),
+    );
     send(response, { status: httpResponse.status, body: httpResponse.body });
 });
 

--- a/infrastructure/backend/express/src/container.ts
+++ b/infrastructure/backend/express/src/container.ts
@@ -1,5 +1,6 @@
 import { userRepository } from "@express/src/postgres/auth/user.adapter";
 import { twoFactorSessionRepository } from "@express/src/postgres/auth/two-factor-session.adapter";
+import { passwordResetTokenRepository } from "@express/src/postgres/auth/password-reset-token.adapter";
 import { adminRepository } from "@express/src/postgres/admin/admin.adapter";
 import { studentRepository } from "@express/src/postgres/student/student.adapter";
 import { instructorRepository } from "@express/src/postgres/instructor/instructor.adapter";
@@ -49,6 +50,7 @@ import { unitOfWork } from "@express/src/postgres/unit-of-work";
 import { passwordHasher } from "@express/src/auth/password-hasher.adapter";
 import { tokenProvider } from "@express/src/auth/token-provider.adapter";
 import { totpProvider } from "@express/src/auth/totp-provider.adapter";
+import { emailSender } from "@express/src/auth/email-sender.adapter";
 
 import { AuthUseCases } from "@application/auth/auth.use-cases";
 import { AdminUseCases } from "@application/admin/admin.use-cases";
@@ -90,6 +92,9 @@ export const authUseCases = new AuthUseCases(
     tokenProvider,
     totpProvider,
     twoFactorSessionRepository,
+    passwordResetTokenRepository,
+    emailSender,
+    process.env.FRONTEND_PUBLIC_URL ?? "http://localhost:3000",
 );
 
 export const adminUseCases = new AdminUseCases(adminRepository);

--- a/infrastructure/backend/express/src/postgres/auth/password-reset-token.adapter.ts
+++ b/infrastructure/backend/express/src/postgres/auth/password-reset-token.adapter.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, gte, lt } from "drizzle-orm";
+import { type PasswordResetTokenRepository } from "@application/auth/password-reset-token.repository";
+import { type PasswordResetToken } from "@domain/auth/password-reset-token.entity";
+import { db } from "@express/src/postgres/db";
+import { passwordResetTokens } from "@express/src/postgres/schema/auth";
+
+function rowToToken(row: typeof passwordResetTokens.$inferSelect): PasswordResetToken {
+    return {
+        token: row.token,
+        userId: row.userId,
+        createdAt: row.createdAt,
+    };
+}
+
+export const passwordResetTokenRepository: PasswordResetTokenRepository = {
+    async create(userId) {
+        const token: PasswordResetToken = {
+            token: randomUUID(),
+            userId,
+            createdAt: new Date(),
+        };
+        await db.insert(passwordResetTokens).values(token);
+        return token;
+    },
+    async find(token, notBefore) {
+        const result = await db
+            .select()
+            .from(passwordResetTokens)
+            .where(and(eq(passwordResetTokens.token, token), gte(passwordResetTokens.createdAt, notBefore)))
+            .limit(1);
+        return result[0] ? rowToToken(result[0]) : undefined;
+    },
+    async delete(token) {
+        await db.delete(passwordResetTokens).where(eq(passwordResetTokens.token, token));
+    },
+    async deleteByUserId(userId) {
+        await db.delete(passwordResetTokens).where(eq(passwordResetTokens.userId, userId));
+    },
+    async deleteOlderThan(cutoff) {
+        await db.delete(passwordResetTokens).where(lt(passwordResetTokens.createdAt, cutoff));
+    },
+};

--- a/infrastructure/backend/express/src/postgres/schema/auth.ts
+++ b/infrastructure/backend/express/src/postgres/schema/auth.ts
@@ -24,3 +24,11 @@ export const twoFactorSessions = pgTable("two_factor_sessions", {
     attempts: integer("attempts").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
 });
+
+export const passwordResetTokens = pgTable("password_reset_tokens", {
+    token: text("token").primaryKey(),
+    userId: text("user_id")
+        .notNull()
+        .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull(),
+});

--- a/infrastructure/frontend/next/app/forgot-password/page.tsx
+++ b/infrastructure/frontend/next/app/forgot-password/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, type ChangeEvent, type FormEvent } from "react";
+import Link from "next/link";
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+    const [sent, setSent] = useState(false);
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setLoading(true);
+        setError("");
+        setSent(false);
+
+        try {
+            const response = await fetch("/api/auth/password/forgot", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email }),
+            });
+            const payload = (await response.json()) as { error?: string; message?: string };
+
+            if (!response.ok) {
+                setError(payload.error ?? "Envoi impossible.");
+                return;
+            }
+
+            setSent(true);
+        } catch {
+            setError("Serveur indisponible.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div
+            className="min-h-screen flex items-center justify-center px-4"
+            style={{ background: "linear-gradient(135deg, #001944 0%, #002C6E 55%, #1d4ed8 100%)" }}
+        >
+            <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8">
+                <h1 className="text-2xl font-bold text-gray-900">Mot de passe oublié</h1>
+                <p className="text-sm text-gray-500 mt-1 mb-6">
+                    Saisissez votre adresse email. Si un compte existe, vous recevrez un lien de réinitialisation.
+                </p>
+
+                {sent ? (
+                    <div className="space-y-4">
+                        <p className="text-sm text-green-800 bg-green-50 border border-green-200 rounded-lg p-3">
+                            Si un compte existe pour cette adresse, un email de réinitialisation a été envoyé. Vérifiez
+                            votre boîte de réception.
+                        </p>
+                        <Link
+                            href="/login"
+                            className="block text-center text-sm text-blue-700 hover:text-blue-900 font-medium"
+                        >
+                            Retour à la connexion
+                        </Link>
+                    </div>
+                ) : (
+                    <form onSubmit={handleSubmit} className="space-y-3">
+                        <div>
+                            <label className="text-xs font-medium text-gray-700 block mb-1">Adresse email</label>
+                            <input
+                                type="email"
+                                value={email}
+                                onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                                className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-400"
+                                required
+                            />
+                        </div>
+
+                        {error && (
+                            <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2">{error}</p>
+                        )}
+
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className="w-full py-2.5 rounded-xl font-semibold text-sm text-white bg-[#001944] hover:bg-[#002C6E] disabled:bg-gray-300"
+                        >
+                            {loading ? "Envoi..." : "Envoyer le lien de réinitialisation"}
+                        </button>
+                    </form>
+                )}
+
+                {!sent && (
+                    <p className="mt-4 text-xs text-center">
+                        <Link href="/login" className="text-blue-700 hover:text-blue-900 font-medium">
+                            Retour à la connexion
+                        </Link>
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/infrastructure/frontend/next/app/login/page.tsx
+++ b/infrastructure/frontend/next/app/login/page.tsx
@@ -206,9 +206,12 @@ export default function LoginPage() {
                     </button>
 
                     {!totpRequired && (
-                        <div className="mt-4 flex items-center justify-start text-xs">
+                        <div className="mt-4 flex items-center justify-between text-xs">
                             <Link href="/signup" className="text-blue-700 hover:text-blue-900 font-medium">
                                 Créer un compte
+                            </Link>
+                            <Link href="/forgot-password" className="text-blue-700 hover:text-blue-900 font-medium">
+                                Mot de passe oublié ?
                             </Link>
                         </div>
                     )}

--- a/infrastructure/frontend/next/app/reset-password/page.tsx
+++ b/infrastructure/frontend/next/app/reset-password/page.tsx
@@ -2,18 +2,24 @@
 
 import { Suspense, useState, type ChangeEvent, type FormEvent } from "react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { cn } from "@/lib/utils";
 
 function ResetPasswordForm() {
+    const router = useRouter();
     const searchParams = useSearchParams();
+    const token = searchParams.get("token");
+    const isForgotFlow = Boolean(token);
+
     const [email, setEmail] = useState(searchParams.get("email") ?? "");
     const [oldPassword, setOldPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
     const [success, setSuccess] = useState("");
 
-    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    const handleCredentialsSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         setLoading(true);
         setError("");
@@ -33,6 +39,38 @@ function ResetPasswordForm() {
             setSuccess(payload.message ?? "Mot de passe mis à jour.");
             setOldPassword("");
             setNewPassword("");
+            setConfirmPassword("");
+        } catch {
+            setError("Serveur indisponible.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleTokenSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (newPassword !== confirmPassword) {
+            setError("Les mots de passe ne correspondent pas.");
+            return;
+        }
+
+        setLoading(true);
+        setError("");
+        setSuccess("");
+
+        try {
+            const response = await fetch("/api/auth/password/reset-with-token", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ token, newPassword }),
+            });
+            const payload = (await response.json()) as { error?: string; message?: string };
+            if (!response.ok) {
+                setError(payload.error ?? "Lien invalide ou expiré.");
+                return;
+            }
+            setSuccess("Mot de passe mis à jour. Vous pouvez vous connecter.");
+            setTimeout(() => router.push("/login"), 2000);
         } catch {
             setError("Serveur indisponible.");
         } finally {
@@ -48,30 +86,41 @@ function ResetPasswordForm() {
             <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-8">
                 <h1 className="text-2xl font-bold text-gray-900">Réinitialisation mot de passe</h1>
                 <p className="text-sm text-gray-500 mt-1 mb-6">
-                    Obligatoire tous les 60 jours - nouveau mot de passe fort requis.
+                    {isForgotFlow
+                        ? "Choisissez un nouveau mot de passe fort (12+ caractères, majuscule, minuscule, chiffre, symbole)."
+                        : "Obligatoire tous les 60 jours — saisissez votre ancien mot de passe et un nouveau mot de passe fort."}
                 </p>
 
-                <form onSubmit={handleSubmit} className="space-y-3">
-                    <div>
-                        <label className="text-xs font-medium text-gray-700 block mb-1">Adresse email</label>
-                        <input
-                            type="email"
-                            value={email}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-                            className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none"
-                            required
-                        />
-                    </div>
-                    <div>
-                        <label className="text-xs font-medium text-gray-700 block mb-1">Ancien mot de passe</label>
-                        <input
-                            type="password"
-                            value={oldPassword}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => setOldPassword(e.target.value)}
-                            className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none"
-                            required
-                        />
-                    </div>
+                <form
+                    onSubmit={isForgotFlow ? handleTokenSubmit : handleCredentialsSubmit}
+                    className="space-y-3"
+                >
+                    {!isForgotFlow && (
+                        <>
+                            <div>
+                                <label className="text-xs font-medium text-gray-700 block mb-1">Adresse email</label>
+                                <input
+                                    type="email"
+                                    value={email}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                                    className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none"
+                                    required
+                                />
+                            </div>
+                            <div>
+                                <label className="text-xs font-medium text-gray-700 block mb-1">
+                                    Ancien mot de passe
+                                </label>
+                                <input
+                                    type="password"
+                                    value={oldPassword}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) => setOldPassword(e.target.value)}
+                                    className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none"
+                                    required
+                                />
+                            </div>
+                        </>
+                    )}
                     <div>
                         <label className="text-xs font-medium text-gray-700 block mb-1">Nouveau mot de passe</label>
                         <input
@@ -82,6 +131,20 @@ function ResetPasswordForm() {
                             required
                         />
                     </div>
+                    {isForgotFlow && (
+                        <div>
+                            <label className="text-xs font-medium text-gray-700 block mb-1">
+                                Confirmer le nouveau mot de passe
+                            </label>
+                            <input
+                                type="password"
+                                value={confirmPassword}
+                                onChange={(e: ChangeEvent<HTMLInputElement>) => setConfirmPassword(e.target.value)}
+                                className="w-full px-3 py-2.5 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none"
+                                required
+                            />
+                        </div>
+                    )}
 
                     {error && (
                         <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2">{error}</p>
@@ -95,7 +158,10 @@ function ResetPasswordForm() {
                     <button
                         type="submit"
                         disabled={loading}
-                        className="w-full py-2.5 rounded-xl font-semibold text-sm text-white bg-[#001944] hover:bg-[#002C6E] disabled:bg-gray-300"
+                        className={cn(
+                            "w-full py-2.5 rounded-xl font-semibold text-sm text-white transition-all",
+                            !loading ? "bg-[#001944] hover:bg-[#002C6E]" : "bg-gray-300 cursor-not-allowed",
+                        )}
                     >
                         {loading ? "Mise à jour..." : "Mettre à jour le mot de passe"}
                     </button>
@@ -113,7 +179,16 @@ function ResetPasswordForm() {
 
 export default function ResetPasswordPage() {
     return (
-        <Suspense>
+        <Suspense
+            fallback={
+                <div
+                    className="min-h-screen flex items-center justify-center px-4"
+                    style={{ background: "linear-gradient(135deg, #001944 0%, #002C6E 55%, #1d4ed8 100%)" }}
+                >
+                    <p className="text-white text-sm">Chargement…</p>
+                </div>
+            }
+        >
             <ResetPasswordForm />
         </Suspense>
     );


### PR DESCRIPTION
Ajoute POST /auth/password/forgot et /reset-with-token, la page /forgot-password et le formulaire token sur /reset-password. En dev, le lien de reset est loggue en console.